### PR TITLE
[modify]: improve .travis file. Use a recursive way to check Markdown links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,15 @@
-install:
-  - npm install -g markdown-link-check
+language: node_js
+
+node_js:
+    - "8.11.1"
+    - "9.11.1"
+
+before_script:
+    - "npm install -g markdown-link-check"
+
 script:
-  - bash ./check_links.sh
+    - "bash ./check_links.sh"
+
+after_script:
+    - "echo ${?}"
+

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 
 res_code=0
-for markdown in *.md; do 
-	markdown-link-check "$markdown"
-	if [ $? -ne 0 ]; then
+
+# Check local markdown files in recursive
+for markdown in `find . -name \*.md`
+do
+	markdown-link-check "${markdown}"
+	if [ ${?} -ne 0 ]; then
 		res_code=1
 	fi
 done
 
-exit $res_code
+exit ${res_code}
+


### PR DESCRIPTION
# 修改项
- 完善`.travis.yml`，项目**持续集成**（CI）功能应该可以正常使用了。
- 改进`check_links.sh`脚本文件，使用**递归方法**遍历，不会遗漏`.md`文件了。
# 建议
`README.md`中的一些外链已挂，建议补链。（参考下图）
`沈阳事件.md`中大部分参考链接都是无效的，`.md`文档结构也很乱，建议完善。
![screen shot 2018-04-26 at 1 38 49](https://user-images.githubusercontent.com/19472493/39262786-f6a148f4-48f2-11e8-8479-563530f5b5e2.png)
